### PR TITLE
fix ZonePrimary tests

### DIFF
--- a/dyn/resource_dyn_zone_primary_test.go
+++ b/dyn/resource_dyn_zone_primary_test.go
@@ -14,6 +14,8 @@ func TestAccDynZonePrimaryBasic(t *testing.T) {
 	var zone dynect.Zone
 	name := os.Getenv("DYN_ZONE")
 
+	testAccDeleteTestDynZone(name, t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -38,6 +40,8 @@ func TestAccDynZonePrimaryBasic(t *testing.T) {
 func TestAccDynZonePrimaryTTL(t *testing.T) {
 	var zone dynect.Zone
 	name := os.Getenv("DYN_ZONE")
+
+	testAccDeleteTestDynZone(name, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -66,6 +70,8 @@ func TestAccDynZonePrimarySerialStyleEpoch(t *testing.T) {
 	var zone dynect.Zone
 	name := os.Getenv("DYN_ZONE")
 
+	testAccDeleteTestDynZone(name, t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -93,6 +99,8 @@ func TestAccDynZonePrimarySerialStyleDay(t *testing.T) {
 	var zone dynect.Zone
 	name := os.Getenv("DYN_ZONE")
 
+	testAccDeleteTestDynZone(name, t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -119,6 +127,8 @@ func TestAccDynZonePrimarySerialStyleDay(t *testing.T) {
 func TestAccDynZonePrimarySerialStyleMinute(t *testing.T) {
 	var zone dynect.Zone
 	name := os.Getenv("DYN_ZONE")
+
+	testAccDeleteTestDynZone(name, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -201,18 +211,32 @@ func testAccCheckDynZonePrimaryExists(n string, record *dynect.Zone) resource.Te
 	}
 }
 
+func testAccDeleteTestDynZone(name string, t *testing.T) {
+
+	client := testAccProvider.Meta().(*dynect.ConvenientClient)
+	foundZone := &dynect.Zone{
+		Zone: name,
+	}
+	err := client.GetZone(foundZone)
+	if err == nil {
+		err := client.DeleteZone(name)
+		if err != nil {
+			t.Logf("%s", err)
+			t.Fail()
+		}
+	}
+}
+
 const testAccCheckDynZonePrimaryConfigBasic = `
 resource "dyn_zone_primary" "foobar" {
 	name = "%s"
 	mailbox = "test@terraform.com"
-	type = "Primary"
 }`
 
 const testAccCheckDynZonePrimaryConfigTTL = `
 resource "dyn_zone_primary" "foobar" {
 	name = "%s"
 	mailbox = "test@terraform.com"
-	type = "Primary"
 	ttl = "60"
 }`
 
@@ -221,7 +245,6 @@ resource "dyn_zone_primary" "foobar" {
 	name = "%s"
 	mailbox = "test@terraform.com"
 	serial_style = "epoch"
-	type = "Primary"
 }`
 
 const testAccCheckDynZonePrimaryConfigSerialStyleDay = `
@@ -229,7 +252,6 @@ resource "dyn_zone_primary" "foobar" {
 	name = "%s"
 	mailbox = "test@terraform.com"
 	serial_style = "day"
-	type = "Primary"
 }`
 
 const testAccCheckDynZonePrimaryConfigSerialStyleMinute = `
@@ -237,5 +259,4 @@ resource "dyn_zone_primary" "foobar" {
 	name = "%s"
 	mailbox = "test@terraform.com"
 	serial_style = "minute"
-	type = "Primary"
 }`


### PR DESCRIPTION
```
#> new-resources-0.12 ●  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/Wikia/terraform-provider-dyn [no test files]
=== RUN   TestAccImportDynRecord_A
--- PASS: TestAccImportDynRecord_A (15.33s)
=== RUN   TestAccImportDynRecord_MX
--- PASS: TestAccImportDynRecord_MX (18.06s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDynRecord_Basic
--- PASS: TestAccDynRecord_Basic (16.93s)
=== RUN   TestAccDynRecord_noTTL
--- PASS: TestAccDynRecord_noTTL (14.43s)
=== RUN   TestAccDynRecord_Updated
--- PASS: TestAccDynRecord_Updated (25.73s)
=== RUN   TestAccDynRecord_Multiple
--- PASS: TestAccDynRecord_Multiple (20.81s)
=== RUN   TestAccDynRecord_CNAME_trailingDot
--- PASS: TestAccDynRecord_CNAME_trailingDot (14.44s)
=== RUN   TestAccDynRecord_CNAME_topLevelDomain
--- PASS: TestAccDynRecord_CNAME_topLevelDomain (14.97s)
=== RUN   TestAccDynRecord_NS_record
--- PASS: TestAccDynRecord_NS_record (17.42s)
=== RUN   TestAccDynRecord_MX_record
--- PASS: TestAccDynRecord_MX_record (14.49s)
=== RUN   TestAccDynZonePrimaryBasic
--- PASS: TestAccDynZonePrimaryBasic (15.56s)
=== RUN   TestAccDynZonePrimaryTTL
--- PASS: TestAccDynZonePrimaryTTL (14.93s)
=== RUN   TestAccDynZonePrimarySerialStyleEpoch
--- PASS: TestAccDynZonePrimarySerialStyleEpoch (14.70s)
=== RUN   TestAccDynZonePrimarySerialStyleDay
--- PASS: TestAccDynZonePrimarySerialStyleDay (14.88s)
=== RUN   TestAccDynZonePrimarySerialStyleMinute
--- PASS: TestAccDynZonePrimarySerialStyleMinute (16.45s)
PASS
ok      github.com/Wikia/terraform-provider-dyn/dyn     249.156s
```